### PR TITLE
Add duration key (MPRIS only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Media Player watcher
 
 This watcher sends information the media which is playing now to [ActivityWatch](https://activitywatch.net/).
-It supports any player which can report its status to the system 
+It supports any player which can report its status to the system
 and be controllable by tray or standard multimedia keys,
 such as Spotify, Foobar, browser-based players, and others. Most media players are supported.
 
@@ -21,7 +21,8 @@ Spotify in Linux:
   "artist": "The Gathering",
   "player": "Spotify",
   "title": "My Electricity",
-  "uri": "https://open.spotify.com/track/1cSWc2kX4z39L5uFdGcjFP"
+  "uri": "https://open.spotify.com/track/1cSWc2kX4z39L5uFdGcjFP",
+  "duration_s": 212
 }
 ```
 Firefox in Linux (no plugins):
@@ -29,7 +30,8 @@ Firefox in Linux (no plugins):
 {
     "artist": "Eileen",
     "player": "Mozilla Firefox",
-    "title": "🇺🇦 🇵🇱 Гей, соколи! / Hej, sokoły! – Ukrainian/Polish folk song"
+    "title": "🇺🇦 🇵🇱 Гей, соколи! / Hej, sokoły! – Ukrainian/Polish folk song",
+    "duration_s": 184
 }
 ```
 MS Edge in Windows:

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -21,6 +21,7 @@ pub struct MediaData {
     album: Option<String>,
     title: Option<String>,
     uri: Option<String>,
+    duration_s: Option<i64>,
     pub player: String,
 }
 
@@ -47,6 +48,9 @@ impl MediaData {
             if !uri.is_empty() {
                 data.insert("uri".to_string(), Value::String(uri.to_string()));
             }
+        }
+        if let Some(duration_s) = &self.duration_s {
+            data.insert("duration_s".to_string(), Value::from(*duration_s));
         }
 
         data

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -91,5 +91,6 @@ fn mediadata(player_finder: &PlayerFinder) -> Option<MediaData> {
                     .collect()
             })
         },
+        duration_s: metadata.length().map(|d| d.as_secs() as i64),
     })
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -37,6 +37,7 @@ impl CrossMediaPlayer for MediaPlayer {
             album,
             title,
             uri: None,
+            duration_s: None,
             player,
         })
     }


### PR DESCRIPTION
I added a `duration_s` key. With this PR, it only works with Linux/MPRIS; I have not researched whether it's possible to obtain on Windows because I cannot quickly test it there anyway.

Fixes #13.