### PR TITLE
Cargo.toml: set package.license to Unlicense

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Demmie <2e3s19@gmail.com>"]
 version = "1.1.3"
 edition = "2021"
 description = "A cross-platform watcher to report currently playing media to ActivityWatch."
-license = "Mozilla Public License 2.0"
+license = "Unlicense"
 
 [dependencies]
 aw-client-rust = { git = "https://github.com/ActivityWatch/aw-server-rust", rev = "448312d" }


### PR DESCRIPTION
Currently inconsistent with LICENSE, which I'd assume to be authoritative.
I am currently packaging this for nixpkgs, which demands clear licensing, and I assume it doesn't hurt to have these consistent either way.